### PR TITLE
SoundsLoader rework

### DIFF
--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Assets/SoundsLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Assets/SoundsLoader.cs
@@ -202,9 +202,6 @@ namespace ClassicUO.Assets
             }
         }
 
-        // MobileUO: this will create a silence of 0.5 sec
-        private static byte[] _SilenceArr = new byte[22050];
-
         public unsafe bool TryGetSound(int sound, out byte[] data, out string name)
         {
             data = null;
@@ -225,12 +222,10 @@ namespace ClassicUO.Assets
             _file.Read(buf);
 
             name = Encoding.UTF8.GetString(buf);
-            data = new byte[entry.Length - 40];
-            _file.Read(data);
+            // MobileUO: added silence -> 22050 (0.5 seconds)
+            data = new byte[entry.Length + 22050 - 40];
+            data = _file.ReadBytes(data.Length - 22050);
 
-            // MobileUO: added silence array
-            data = data.Concat(_SilenceArr).ToArray();
-            
             return true;
         }
 

--- a/Assets/Scripts/ClassicUO/src/ClassicUO.IO/FileReader.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.IO/FileReader.cs
@@ -29,6 +29,7 @@ namespace ClassicUO.IO
         }
 
         public void Seek(long index, SeekOrigin origin) => _position = Reader.BaseStream.Seek(index, origin);
+        public byte[] ReadBytes(int lenght) { _position += lenght; return Reader.ReadBytes(lenght); }
         public sbyte ReadInt8() { _position += sizeof(sbyte); return Reader.ReadSByte(); }
         public byte ReadUInt8() { _position += sizeof(byte); return Reader.ReadByte(); }
         public short ReadInt16() { _position += sizeof(short); return Reader.ReadInt16(); }


### PR DESCRIPTION
- SoundsLoader: remake so that it doesn't use extra memory in recreating arrays 3 times
- Add in FileLoader the corresponding needed to fill only part of the array with the requested data