### PR TITLE
Fixed "Force Use XBR" feature - if enabled it will now correctly use …

### DIFF
--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -997,12 +997,19 @@ namespace ClassicUO.Game.Scenes
                 //        break;
                 //}
 
-                if (_xbr == null)
+                if (ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.UseXBR)
                 {
-                    _xbr = new XBREffect(batcher.GraphicsDevice);
-                }
+                    if (_xbr == null)
+                    {
+                        _xbr = new XBREffect(batcher.GraphicsDevice);
+                    }
 
-                _xbr.TextureSize.SetValue(new Vector2(Camera.Bounds.Width, Camera.Bounds.Height));
+                    _xbr.TextureSize.SetValue(new Vector2(Camera.Bounds.Width, Camera.Bounds.Height));
+
+                    batcher.Begin(_xbr, Camera.ViewTransformMatrix);
+                }
+                else
+                    batcher.Begin(null, Camera.ViewTransformMatrix);
 
                 //Point p = Point.Zero;
 
@@ -1016,7 +1023,6 @@ namespace ClassicUO.Game.Scenes
                 //int maxPixelsX = p.X;
                 //int maxPixelsY = p.Y;
 
-                batcher.Begin(null, Camera.ViewTransformMatrix);
 
                 // MobileUO: fix game window being deattached from view port
                 batcher.Draw(


### PR DESCRIPTION
…XBR, but only for DrawTexture() calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a profile setting to enable or disable XBR upscaling for improved visual clarity.
- Bug Fixes
  - Ensured clipping/scissor behavior is consistent when XBR upscaling is active.
  - Corrected rendering of atlas sub-textures when using XBR, improving sharpness and alignment.
- Refactor
  - Optimized rendering flow to create and apply the XBR effect only when enabled, reducing unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->