### PR TITLE
Added zoom in and out buttons to world map gump context menu

### DIFF
--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -352,7 +352,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             // MobileUO: added zoom buttons
             _options["zoom_in"] = new ContextMenuItemEntry("Zoom In (+)", () => OnMouseWheel(MouseEventType.WheelScrollUp));
-            _options["zoom_out"] = new ContextMenuItemEntry("Zoom Out (–)", () => OnMouseWheel(MouseEventType.Down));
+            _options["zoom_out"] = new ContextMenuItemEntry("Zoom Out (-)", () => OnMouseWheel(MouseEventType.WheelScrollDown));
         }
 
         public void GoToMarker(int x, int y, bool isManualType)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - World Map: Added "Zoom In (+)" and "Zoom Out (-)" entries to the map context menu for direct zoom control.
  - Improves accessibility for devices without scroll input and provides predictable zoom steps from the menu.
  - Existing zoom methods (mouse wheel and shortcuts) remain unchanged and continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->