### PR TITLE
correct licensing for own files

### DIFF
--- a/Assets/Scripts/Assistant/ActionQueue.cs
+++ b/Assets/Scripts/Assistant/ActionQueue.cs
@@ -1,4 +1,19 @@
-﻿using ClassicUO.Game;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using ClassicUO.Game;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Assets/Scripts/Assistant/Assistant.cs
+++ b/Assets/Scripts/Assistant/Assistant.cs
@@ -1,25 +1,18 @@
 ﻿#region license
-//  Copyright (C) 2019 ClassicUO Development Community on Github
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
 //
-//	This project is an alternative client for the game Ultima Online.
-//	The goal of this is to develop a lightweight client considering 
-//	new technologies.  
-//      
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#endregion
-
-using Assistant;
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregionusing Assistant;
 using Assistant.Scripts;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;

--- a/Assets/Scripts/Assistant/Assistant.cs
+++ b/Assets/Scripts/Assistant/Assistant.cs
@@ -12,7 +12,8 @@
 //
 // This program is distributed WITHOUT ANY WARRANTY. 
 // See <https://www.gnu.org> for details.
-#endregionusing Assistant;
+#endregion
+using Assistant;
 using Assistant.Scripts;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;

--- a/Assets/Scripts/Assistant/BandageTimer.cs
+++ b/Assets/Scripts/Assistant/BandageTimer.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 
 using ClassicUO.IO.Resources;
 

--- a/Assets/Scripts/Assistant/BodCapture.cs
+++ b/Assets/Scripts/Assistant/BodCapture.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Collections.Generic;
 using System.IO;
 using ClassicUO.Configuration;

--- a/Assets/Scripts/Assistant/BuffIcons.cs
+++ b/Assets/Scripts/Assistant/BuffIcons.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 
 namespace Assistant.Core
 {

--- a/Assets/Scripts/Assistant/Dress.cs
+++ b/Assets/Scripts/Assistant/Dress.cs
@@ -1,4 +1,19 @@
-﻿namespace Assistant.Core
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+namespace Assistant.Core
 {
     internal static class Dress
     {

--- a/Assets/Scripts/Assistant/DressList.cs
+++ b/Assets/Scripts/Assistant/DressList.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Collections.Generic;
 using System.Xml;
 using Assistant.Core;

--- a/Assets/Scripts/Assistant/Engine.cs
+++ b/Assets/Scripts/Assistant/Engine.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Collections.Generic;

--- a/Assets/Scripts/Assistant/Filters.cs
+++ b/Assets/Scripts/Assistant/Filters.cs
@@ -1,4 +1,19 @@
-﻿using System.Xml;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System.Xml;
 using System.Collections.Generic;
 
 using ClassicUO.Network;

--- a/Assets/Scripts/Assistant/Foods.cs
+++ b/Assets/Scripts/Assistant/Foods.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Assets/Scripts/Assistant/FriendsManager.cs
+++ b/Assets/Scripts/Assistant/FriendsManager.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/Assets/Scripts/Assistant/GateTimer.cs
+++ b/Assets/Scripts/Assistant/GateTimer.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Linq;
 
 using ClassicUO.IO.Resources;

--- a/Assets/Scripts/Assistant/Hotkeys.cs
+++ b/Assets/Scripts/Assistant/Hotkeys.cs
@@ -1,4 +1,19 @@
-﻿using ClassicUO.Game;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using ClassicUO.Game;
 using ClassicUO.Network;
 using ClassicUO.Game.Managers;
 using ClassicUO.IO.Resources;

--- a/Assets/Scripts/Assistant/InternalUI/AssistArrowNumbersTextBox.cs
+++ b/Assets/Scripts/Assistant/InternalUI/AssistArrowNumbersTextBox.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 
 using ClassicUO.Renderer;
 using ClassicUO.Utility;

--- a/Assets/Scripts/Assistant/InternalUI/AssistCheckbox.cs
+++ b/Assets/Scripts/Assistant/InternalUI/AssistCheckbox.cs
@@ -1,24 +1,18 @@
 ﻿#region license
-// Copyright (C) 2020 ClassicUO Development Community on Github
+// Copyright (C) 2022-2025 Sascha Puligheddu
 // 
-// This project is an alternative client for the game Ultima Online.
-// The goal of this is to develop a lightweight client considering
-// new technologies.
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
 // 
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
 // 
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-// 
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
 #endregion
-
 using System;
 using System.Collections.Generic;
 

--- a/Assets/Scripts/Assistant/InternalUI/AssistHotkeyBox.cs
+++ b/Assets/Scripts/Assistant/InternalUI/AssistHotkeyBox.cs
@@ -1,24 +1,18 @@
 ﻿#region license
-// Copyright (C) 2020 ClassicUO Development Community on Github
+// Copyright (C) 2022-2025 Sascha Puligheddu
 // 
-// This project is an alternative client for the game Ultima Online.
-// The goal of this is to develop a lightweight client considering
-// new technologies.
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
 // 
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
 // 
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-// 
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
 #endregion
-
 using System;
 using System.Linq;
 using System.Text;

--- a/Assets/Scripts/Assistant/InternalUI/AssistMultiSelectionShrinkBox.cs
+++ b/Assets/Scripts/Assistant/InternalUI/AssistMultiSelectionShrinkBox.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Assets/Scripts/Assistant/InternalUI/NiceButtonStbText.cs
+++ b/Assets/Scripts/Assistant/InternalUI/NiceButtonStbText.cs
@@ -1,4 +1,19 @@
-﻿using System.Collections.Generic;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System.Collections.Generic;
 using System.Linq;
 using System;
 

--- a/Assets/Scripts/Assistant/InternalUI/SelectableReadOnlyBox.cs
+++ b/Assets/Scripts/Assistant/InternalUI/SelectableReadOnlyBox.cs
@@ -1,4 +1,19 @@
-﻿using ClassicUO.Input;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using ClassicUO.Input;
 using ClassicUO.IO.Resources;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;

--- a/Assets/Scripts/Assistant/Map.cs
+++ b/Assets/Scripts/Assistant/Map.cs
@@ -1,4 +1,19 @@
-﻿namespace Assistant
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+namespace Assistant
 {
     public class MultiTileEntry
     {

--- a/Assets/Scripts/Assistant/Network/Handlers.cs
+++ b/Assets/Scripts/Assistant/Network/Handlers.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Original logic from original Razor Assistant
+// Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
+// 
+// This specific derivative work is licensed under GNU AGPLv3.
+using System;
 using System.Text;
 using System.Collections.Generic;
 using System.Linq;

--- a/Assets/Scripts/Assistant/Network/PacketHandlers.cs
+++ b/Assets/Scripts/Assistant/Network/PacketHandlers.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Original logic from original Razor Assistant
+// Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
+// 
+// This specific derivative work is licensed under GNU AGPLv3.
+using System;
 using System.Collections.Generic;
 using ClassicUO.Utility.Logging;
 using ClassicUO.Network;

--- a/Assets/Scripts/Assistant/Network/Packets.cs
+++ b/Assets/Scripts/Assistant/Network/Packets.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Original logic from original Razor Assistant
+// Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
+// 
+// This specific derivative work is licensed under GNU AGPLv3.
+using System;
 using System.Text;
 using System.Collections.Generic;
 

--- a/Assets/Scripts/Assistant/Network/Ping.cs
+++ b/Assets/Scripts/Assistant/Network/Ping.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Original logic from original Razor Assistant
+// 
+// This specific derivative work is licensed under GNU AGPLv3.
+using System;
 
 namespace Assistant
 {

--- a/Assets/Scripts/Assistant/ObjectPropertyList.cs
+++ b/Assets/Scripts/Assistant/ObjectPropertyList.cs
@@ -1,4 +1,19 @@
-﻿using System.Diagnostics.Contracts;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System.Diagnostics.Contracts;
 using System.Text;
 using System.Collections.Generic;
 

--- a/Assets/Scripts/Assistant/Organizer.cs
+++ b/Assets/Scripts/Assistant/Organizer.cs
@@ -1,4 +1,19 @@
-﻿using ClassicUO.Game;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using ClassicUO.Game;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.Managers;
 using System;

--- a/Assets/Scripts/Assistant/Player.cs
+++ b/Assets/Scripts/Assistant/Player.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;

--- a/Assets/Scripts/Assistant/Scavenger.cs
+++ b/Assets/Scripts/Assistant/Scavenger.cs
@@ -1,4 +1,19 @@
-﻿using System.Collections.Generic;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System.Collections.Generic;
 using ClassicUO.Utility.Collections;
 using ClassicUO.Network;
 using ClassicUO.Game;

--- a/Assets/Scripts/Assistant/Scripts/Aliases.cs
+++ b/Assets/Scripts/Assistant/Scripts/Aliases.cs
@@ -1,4 +1,19 @@
-﻿using UOScript;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using UOScript;
 using ClassicUO.Game;
 
 namespace Assistant.Scripts

--- a/Assets/Scripts/Assistant/Scripts/Commands.cs
+++ b/Assets/Scripts/Assistant/Scripts/Commands.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;

--- a/Assets/Scripts/Assistant/Scripts/Commands.cs
+++ b/Assets/Scripts/Assistant/Scripts/Commands.cs
@@ -1,17 +1,17 @@
 ﻿#region license
+// Original interpreter logic by Jaedan (2022)
+// Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
+// 
 // Copyright (C) 2022-2025 Sascha Puligheddu
 // 
-// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
-// Developed as a lightweight, native assistant.
-// 
-// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// This specific derivative work is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
 // 
 // SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
 // is permitted, provided that the integrated result remains publicly accessible 
 // and the AGPL-3.0 terms are respected for this specific module.
 //
 // This program is distributed WITHOUT ANY WARRANTY. 
-// See <https://www.gnu.org> for details.
+// See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
 #endregion
 using System;
 using System.IO;

--- a/Assets/Scripts/Assistant/Scripts/Expressions.cs
+++ b/Assets/Scripts/Assistant/Scripts/Expressions.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Original interpreter logic by Jaedan (2022)
+// Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
+// 
+// This specific derivative work is licensed under GNU AGPLv3.
+using System;
 using System.Collections.Generic;
 using UOScript;
 

--- a/Assets/Scripts/Assistant/Scripts/Expressions.cs
+++ b/Assets/Scripts/Assistant/Scripts/Expressions.cs
@@ -1,7 +1,18 @@
-﻿// Original interpreter logic by Jaedan (2022)
+﻿#region license
+// Original interpreter logic by Jaedan (2022)
 // Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
 // 
-// This specific derivative work is licensed under GNU AGPLv3.
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This specific derivative work is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
+#endregion
 using System;
 using System.Collections.Generic;
 using UOScript;

--- a/Assets/Scripts/Assistant/Scripts/Interpreter.cs
+++ b/Assets/Scripts/Assistant/Scripts/Interpreter.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Original interpreter logic by Jaedan (2022)
+// Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
+// 
+// This specific derivative work is licensed under GNU AGPLv3.
+using System;
 using System.Threading;
 using System.Linq;
 using System.Collections.Generic;

--- a/Assets/Scripts/Assistant/Scripts/Interpreter.cs
+++ b/Assets/Scripts/Assistant/Scripts/Interpreter.cs
@@ -1,7 +1,18 @@
-﻿// Original interpreter logic by Jaedan (2022)
+﻿#region license
+// Original interpreter logic by Jaedan (2022)
 // Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
 // 
-// This specific derivative work is licensed under GNU AGPLv3.
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This specific derivative work is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
+#endregion
 using System;
 using System.Threading;
 using System.Linq;

--- a/Assets/Scripts/Assistant/Scripts/Lexer.cs
+++ b/Assets/Scripts/Assistant/Scripts/Lexer.cs
@@ -1,7 +1,18 @@
-﻿// Original interpreter logic by Jaedan (2022)
+﻿#region license
+// Original interpreter logic by Jaedan (2022)
 // Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
 // 
-// This specific derivative work is licensed under GNU AGPLv3.
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This specific derivative work is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
+#endregion
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Assets/Scripts/Assistant/Scripts/Lexer.cs
+++ b/Assets/Scripts/Assistant/Scripts/Lexer.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Original interpreter logic by Jaedan (2022)
+// Heavily modified, rewritten and maintained by Sascha Puligheddu (2023-2025)
+// 
+// This specific derivative work is licensed under GNU AGPLv3.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Assets/Scripts/Assistant/Scripts/ScriptTextBox.cs
+++ b/Assets/Scripts/Assistant/Scripts/ScriptTextBox.cs
@@ -1,4 +1,19 @@
-﻿using ClassicUO.Input;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using ClassicUO.Input;
 using ClassicUO.IO.Resources;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;

--- a/Assets/Scripts/Assistant/SkillsHotkeys.cs
+++ b/Assets/Scripts/Assistant/SkillsHotkeys.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Text;
 using System.Linq;
 using System.Collections.Generic;

--- a/Assets/Scripts/Assistant/Spell.cs
+++ b/Assets/Scripts/Assistant/Spell.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;

--- a/Assets/Scripts/Assistant/StealthSteps.cs
+++ b/Assets/Scripts/Assistant/StealthSteps.cs
@@ -1,4 +1,19 @@
-﻿namespace Assistant
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+namespace Assistant
 {
     public class StealthSteps
     {

--- a/Assets/Scripts/Assistant/Targeting.cs
+++ b/Assets/Scripts/Assistant/Targeting.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Linq;
 using System.Collections.Generic;
 

--- a/Assets/Scripts/Assistant/Timer.cs
+++ b/Assets/Scripts/Assistant/Timer.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Collections.Generic;
 
 namespace Assistant

--- a/Assets/Scripts/Assistant/UOEntity.cs
+++ b/Assets/Scripts/Assistant/UOEntity.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.Collections.Generic;
 
 using ClassicUO.Network;

--- a/Assets/Scripts/Assistant/UOItem.cs
+++ b/Assets/Scripts/Assistant/UOItem.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.IO;
 using System.Collections.Generic;
 //TODO: Agents

--- a/Assets/Scripts/Assistant/UOMobile.cs
+++ b/Assets/Scripts/Assistant/UOMobile.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Text;

--- a/Assets/Scripts/Assistant/Utility.cs
+++ b/Assets/Scripts/Assistant/Utility.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.IO;
 using System.Text;
 using System.Globalization;

--- a/Assets/Scripts/Assistant/Vendors.cs
+++ b/Assets/Scripts/Assistant/Vendors.cs
@@ -1,4 +1,19 @@
-﻿using System.Collections.Generic;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System.Collections.Generic;
 using ClassicUO.Utility.Collections;
 using ClassicUO.Network;
 using ClassicUO.Game;

--- a/Assets/Scripts/Assistant/XmlFileParser.cs
+++ b/Assets/Scripts/Assistant/XmlFileParser.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿#region license
+// Copyright (C) 2022-2025 Sascha Puligheddu
+// 
+// This project is a complete reproduction of AssistUO for MobileUO and ClassicUO.
+// Developed as a lightweight, native assistant.
+// 
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
+// 
+// SPECIAL PERMISSION: Integration with projects under BSD 2-Clause (like ClassicUO)
+// is permitted, provided that the integrated result remains publicly accessible 
+// and the AGPL-3.0 terms are respected for this specific module.
+//
+// This program is distributed WITHOUT ANY WARRANTY. 
+// See <https://www.gnu.org> for details.
+#endregion
+using System;
 using System.IO;
 using System.Reflection;
 using System.Globalization;


### PR DESCRIPTION
This PR updates the licensing headers for the modules I have authored and maintained. The goal is to establish a solid legal baseline under GPLv3, ensuring long-term protection for this work and its contributors.

Standardizing this license is a necessary step to facilitate the upcoming submission of major updates to the assistant core. A clear licensing state allows for a more consistent merging process and protects the integrity of the integrated features moving forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated license and attribution headers across the codebase to AGPL-3.0 with special permission notes.

* **Other**
  * No user-facing changes; application behavior and public APIs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->