### PR TITLE
Update UnityBatcher.cs

### DIFF
--- a/Assets/Scripts/UnityBatcher.cs
+++ b/Assets/Scripts/UnityBatcher.cs
@@ -2004,7 +2004,7 @@ namespace ClassicUO.Renderer
 		    float rotationSin, float rotationCos,
 		    float depth,
 		    byte effects,
-		    bool isFromTextureAtlas
+		    bool isFromTextureAtlas //TODO remove this
 		)
 		{
 		    // move checks outside and render them a constant for the whole operation
@@ -2012,17 +2012,9 @@ namespace ClassicUO.Renderer
 		    if (DIVIDE_DEPTH) depth /= 1000f;
 		
 		    // prepare the UV inversion for atlas (zero multiple calls and external functions)
-		    if (isFromTextureAtlas)
-		    {
-		        sourceY += sourceH;
-		        sourceH = -sourceH;
-		    }
-		    else
-		    {
-		        sourceY += sourceH;
-		        sourceH = -sourceH;
-		    }
-		
+		    sourceY += sourceH;
+			sourceH = -sourceH;
+
 		    int eff = effects & 0x03;
 		
 		    fixed (PositionNormalTextureColor4* pSprite = &sprite)

--- a/Assets/Scripts/UnityBatcher.cs
+++ b/Assets/Scripts/UnityBatcher.cs
@@ -2042,7 +2042,7 @@ namespace ClassicUO.Renderer
 		            // NORMAL (Offset 3, 4, 5)
 		            // normal are constants (0,0,1). 
 		            // Extreme optimization: we should write them only if there is a change
-		            *((Vector3*)f + 3) = Vector3.forward;
+		            *((Vector3*)(f + 3)) = Vector3.forward;
 		
 		            // UV (Offset 6, 7, 8)
 		            // use pre-calculated index for correct angles (0,1,2,3)


### PR DESCRIPTION
optimize SetVertex to use unsafe and native calls, zero CPU overhead, almost zero heap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized vertex processing for faster, more efficient rendering and reduced per-frame overhead.
* **Visual / Bug Fixes**
  * Improved texture UV handling and simplified depth processing to reduce rendering artifacts and produce more stable sprite visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->