### PR TITLE
Fixed issue where the Assistant was loading its own skills.xml file 

### DIFF
--- a/Assets/Scripts/Assistant/XmlFileParser.cs
+++ b/Assets/Scripts/Assistant/XmlFileParser.cs
@@ -425,6 +425,14 @@ namespace Assistant
         internal static void LoadSkillDef(FileInfo info, AssistantGump gump)
         {
             List<SkillEntry> skillEntries = new List<SkillEntry>();
+
+            // MobileUO: Use skills already loaded from skills.mul instead of XML file to preserve custom skill names
+            // This fixes the issue where the assistant loading this .xml file was breaking shards like Memento
+            // where they have custom skill names
+            skillEntries.AddRange(Client.Game.UO.FileManager.Skills.SortedSkills);
+
+            // Old XML loading code commented out
+            /*
             XmlDocument doc = new XmlDocument();
             if(!info.Exists)
             {
@@ -473,12 +481,13 @@ namespace Assistant
             {
                 skillEntries.AddRange(Client.Game.UO.FileManager.Skills.Skills);
             }
+            */
 
             Dictionary<int, string> skn = new Dictionary<int, string>
             {
                 [-1] = "Last"
             };
-            for (i = 0; i < skillEntries.Count; i++)
+            for (int i = 0; i < skillEntries.Count; i++)
             {
                 SkillEntry sk = skillEntries[i];
                 if (sk.HasAction)


### PR DESCRIPTION
which was overwriting all skills loaded from skills.mul. This fixes the issue where the custom skill names for shards like Memento were being overwritten by the defaults from the skills.xml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Skill entries now load from the app’s existing skill list, improving consistency and avoiding issues caused by XML-based parsing.
  * Skill hotkeys and skill mappings continue to update as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->