### PR TITLE
Fixed potential issue with parsing mobtypes.txt 

### DIFF
--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Assets/AnimationsLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Assets/AnimationsLoader.cs
@@ -137,7 +137,7 @@ namespace ClassicUO.Assets
                                 continue;
                             }
 
-                            uint number = uint.Parse(parts[2], NumberStyles.HexNumber);
+                            uint number = uint.Parse(parts[2].Trim(), NumberStyles.HexNumber);
 
                             for (int i = 0; i < 5; i++)
                             {

--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Assets/AnimationsLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Assets/AnimationsLoader.cs
@@ -137,6 +137,7 @@ namespace ClassicUO.Assets
                                 continue;
                             }
 
+                            // MobileUO: backported .Trim() fix to handle extra spaces in mobtypes.txt
                             uint number = uint.Parse(parts[2].Trim(), NumberStyles.HexNumber);
 
                             for (int i = 0; i < 5; i++)


### PR DESCRIPTION
when there are extras spaces than expected. This was noticed in UOAlive's latest version of 7.0.116.0

Example bad input:

1698 EQUIPMENT 10000  # Tanto_G- NO ANIMATION - PLACEHOLDER FOR PAPERDOLL 1
699 EQUIPMENT 10000   # Otsuchi_G- NO ANIMATION - PLACEHOLDER FOR PAPERDOLL 
1700 EQUIPMENT 10000   # Bokuto_G- NO ANIMATION - PLACEHOLDER FOR PAPERDOLL

there are multiple spaces before # comment instead of one tab space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation data loading by correctly handling extra whitespace in mob type definitions.
  * Prevented valid hexadecimal values from failing during parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->