### PR TITLE
Added option to toggle adding a light black border around text

### DIFF
--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Assets/FontsLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Assets/FontsLoader.cs
@@ -27,6 +27,7 @@ namespace ClassicUO.Assets
         private const int UOFONT_EXTRAHEIGHT = 0x0100;
         private const int UOFONT_CROPTEXTURE = 0x0200;
         private const int UOFONT_FIXEDHEIGHT = 0x0400;
+        private const int UOFONT_LIGHT_BLACK_BORDER = 0x0800;
         private const int UNICODE_SPACE_WIDTH = 8;
         private const int MAX_HTML_TEXT_HEIGHT = 18;
         private const byte NOPRINT_CHARS = 32;
@@ -1747,8 +1748,11 @@ namespace ClassicUO.Assets
                 bool isItalic = (flags & UOFONT_ITALIC) != 0;
                 bool isSolid = (flags & UOFONT_SOLID) != 0;
                 bool isBlackBorder = (flags & UOFONT_BLACK_BORDER) != 0;
+                bool isLightBlackBorder = (flags & UOFONT_LIGHT_BLACK_BORDER) != 0;
                 bool isUnderline = (flags & UOFONT_UNDERLINE) != 0;
                 uint blackColor = 0xFF010101;
+                uint lightBlackColor = 0xFF181818; // 0xFFFEFEFE - white;  0xFF2B2B2B - light gray; 0xFF141414 -- darker gray
+                uint borderColor = isLightBlackBorder ? lightBlackColor : blackColor;
                 bool isLink = false;
                 int linkStartX = 0;
                 int linkStartY = 0;
@@ -2069,7 +2073,7 @@ namespace ClassicUO.Assets
                                 }
                             }
 
-                            if (isBlackBorder && !isBlackPixel)
+                            if ((isBlackBorder || isLightBlackBorder) && !isBlackPixel)
                             {
                                 int minXOk = w + offsX > 0 ? -1 : 0;
                                 int minYOk = offsY + lineOffsY > 0 ? -1 : 0;
@@ -2110,7 +2114,7 @@ namespace ClassicUO.Assets
 
                                         int block = testY * width + testX;
 
-                                        if (pData[block] == 0 && pData[block] != blackColor)
+                                        if (pData[block] == 0 && pData[block] != borderColor)
                                         {
                                             int startX = cx > 0 ? -1 : 0;
                                             int startY = cy > 0 ? -1 : 0;
@@ -2140,10 +2144,10 @@ namespace ClassicUO.Assets
                                                     if (
                                                         testBlock < pData.Length
                                                         && pData[testBlock] != 0
-                                                        && pData[testBlock] != blackColor
+                                                        && pData[testBlock] != borderColor
                                                     )
                                                     {
-                                                        pData[block] = blackColor;
+                                                        pData[block] = borderColor;
                                                         passed = true;
 
                                                         break;

--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Configuration/Profile.cs
@@ -324,6 +324,8 @@ namespace ClassicUO.Configuration
 
         //Alternate Journal
         public bool UseAlternateJournal { get; set; }
+        // MobileUO: added option to use alternate journal text border for better readability
+        public bool UseAlternateJournalTextBorder { get; set; }
         // MobileUO: added option to allow large chat box to be easier to click on
         public bool UseLargeSystemChatTextBox { get; set; }
 

--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
@@ -25,7 +25,8 @@ namespace ClassicUO.Game
         Cropped = 0x0040,
         BQ = 0x0080,
         ExtraHeight = 0x0100,
-        CropTexture = 0x0200
+        CropTexture = 0x0200,
+        LightBlackBorder = 0x0800
     }
 
     internal sealed class RenderedText

--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -125,7 +125,8 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _showInfoBar;
         private Checkbox _ignoreAllianceMessages;
         // MobileUO: added option to allow large chat box to be easier to click on
-        private Checkbox _ignoreGuildMessages, _useAlternateJournal, _useLargeSystemChatTextBox;
+        // MobileUO: added option to use alternate journal text border for better readability
+        private Checkbox _ignoreGuildMessages, _useAlternateJournal, _useLargeSystemChatTextBox, _useAlternateJournalTextBorder;
 
         // general
         private HSliderBar _sliderFPS, _circleOfTranspRadius;
@@ -2531,8 +2532,22 @@ namespace ClassicUO.Game.UI.Gumps
                 startY
             );
 
-            // MobileUO: added option to allow large chat box to be easier to click on
+            // MobileUO: added option to use alternate journal text border for better readability
+            startX += 40;
             startY += _useAlternateJournal.Height + 2;
+
+            _useAlternateJournalTextBorder = AddCheckBox
+            (
+                rightArea,
+                "Add text border to alternate journal text",
+                _currentProfile.UseAlternateJournalTextBorder,
+                startX,
+                startY
+            );
+
+            // MobileUO: added option to allow large chat box to be easier to click on
+            startY += _useAlternateJournalTextBorder.Height + 2;
+            startX = 5;
 
             _useLargeSystemChatTextBox = AddCheckBox
             (
@@ -3691,6 +3706,8 @@ namespace ClassicUO.Game.UI.Gumps
                     _ignoreGuildMessages.IsChecked = false;
                     _ignoreAllianceMessages.IsChecked = false;
                     _useAlternateJournal.IsChecked = false;
+                    // MobileUO: added option to use alternate journal text border for better readability
+                    _useAlternateJournalTextBorder.IsChecked = false;
                     // MobileUO: added option to allow large chat box to be easier to click on
                     _useLargeSystemChatTextBox.IsChecked = false;
 
@@ -4065,6 +4082,8 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.IgnoreGuildMessages = _ignoreGuildMessages.IsChecked;
             _currentProfile.IgnoreAllianceMessages = _ignoreAllianceMessages.IsChecked;
             _currentProfile.UseAlternateJournal = _useAlternateJournal.IsChecked;
+            // MobileUO: added option to use alternate journal text border for better readability
+            _currentProfile.UseAlternateJournalTextBorder = _useAlternateJournalTextBorder.IsChecked;
             // MobileUO: added option to allow large chat box to be easier to click on
             _currentProfile.UseLargeSystemChatTextBox = _useLargeSystemChatTextBox.IsChecked;
 

--- a/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
+++ b/Assets/Scripts/ClassicUO/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
@@ -368,7 +368,10 @@ namespace ClassicUO.Game.UI.Gumps
                     // MobileUO: backported linewrap fix
                     foreach (JournalData jdata in journalDatas)
                     {
-                        jdata.EntryText = new Label(jdata.EntryText.Text, jdata.EntryText.Unicode, jdata.EntryText.Hue, Width - BORDER_WIDTH - jdata.TimeStamp.Width, font: jdata.EntryText.Font);
+                        // MobileUO: added option to use alternate journal text border for better readability
+                        var fontStyle = GetJournalFontStyle();
+
+                        jdata.EntryText = new Label(jdata.EntryText.Text, jdata.EntryText.Unicode, jdata.EntryText.Hue, Width - BORDER_WIDTH - jdata.TimeStamp.Width, font: jdata.EntryText.Font, style: fontStyle);
                         jdata.EntryText.Update();
                     }
 
@@ -415,12 +418,15 @@ namespace ClassicUO.Game.UI.Gumps
                 while (journalDatas.Count > Constants.MAX_JOURNAL_HISTORY_COUNT)
                     journalDatas.RemoveFromFront().Destroy();
 
-                Label timeS = new Label($"{e.Time:t}", e.IsUnicode, e.Hue, font: e.Font);
+                // MobileUO: added option to use alternate journal text border for better readability
+                var fontStyle = GetJournalFontStyle();
+
+                Label timeS = new Label($"{e.Time:t}", e.IsUnicode, e.Hue, font: e.Font, style: fontStyle);
 
                 journalDatas.AddToBack(
                     new JournalData(
                         // MobileUO: backported linewrap fix
-                        new Label($"{e.Name}: {e.Text}", e.IsUnicode, e.Hue, Width - BORDER_WIDTH - timeS.Width, font: e.Font),
+                        new Label($"{e.Name}: {e.Text}", e.IsUnicode, e.Hue, Width - BORDER_WIDTH - timeS.Width, font: e.Font, style: fontStyle),
                         timeS,
                         e.TextType,
                         e.MessageType
@@ -462,6 +468,13 @@ namespace ClassicUO.Game.UI.Gumps
                     _.Destroy();
 
                 journalDatas.Clear();
+            }
+
+            private FontStyle GetJournalFontStyle()
+            {
+                return ProfileManager.CurrentProfile.UseAlternateJournalTextBorder
+                    ? FontStyle.LightBlackBorder
+                    : FontStyle.None;
             }
 
             public override void Dispose()


### PR DESCRIPTION
 in the alternate journal to help with contrast and readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to display alternate journal text with a lighter border for improved readability.
  * Added support for light black borders in text rendering.
  * The setting is available in the Speech options and applies to existing and new journal entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->